### PR TITLE
Node-exporter memory fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
+GIT_HASH=$(shell git show | head -1 | cut -d" " -f2)
+
 all:
+	echo "== Building dashboards with git hash: $(GIT_HASH) =="
+	find dashboards/* -type f -exec sed -i -e s/%{GIT_HASH}%/$(GIT_HASH)/g {} \;
 	find dashboards/* -type f -exec ./template-cleaner.py {} \;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	find dashboards/* -type f -exec ./template-cleaner.py {} \;

--- a/dashboards/MongoDB_Config_Server_Instance.json
+++ b/dashboards/MongoDB_Config_Server_Instance.json
@@ -48,7 +48,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_load1{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -98,7 +98,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (instance))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -148,7 +148,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (instance))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -198,7 +198,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (instance))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -248,7 +248,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-((node_memory_MemAvailable{nodetype=\"config\",alias=\"$mongod\"} or (node_memory_Buffers{nodetype=\"config\",alias=\"$mongod\"} + node_memory_Cached{nodetype=\"config\",alias=\"$mongod\"}))/node_memory_MemTotal{alias=\"$mongod\"})",
+                            "expr": "1-((node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))/node_memory_MemTotal{alias=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -1480,21 +1480,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_load1{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "node_load5{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_load5{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 21
                         },
                         {
-                            "expr": "node_load15{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_load15{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -1561,7 +1561,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -1569,7 +1569,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -1577,7 +1577,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -1585,7 +1585,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -1593,7 +1593,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -1663,7 +1663,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{nodetype=\"config\",alias=\"$mongod\"} or (node_memory_Buffers{nodetype=\"config\",alias=\"$mongod\"} + node_memory_Cached{nodetype=\"config\",alias=\"$mongod\"})",
+                            "expr": "node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -1671,7 +1671,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_MemTotal{nodetype=\"config\",alias=\"$mongod\"}-(node_memory_MemAvailable{nodetype=\"config\",alias=\"$mongod\"} or (node_memory_Buffers{nodetype=\"config\",alias=\"$mongod\"} + node_memory_Cached{nodetype=\"config\",alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}-(node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "used",
@@ -1679,21 +1679,21 @@
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_MemTotal{nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_Buffers{nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_Cached{nodetype=\"config\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
@@ -1835,14 +1835,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_read_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "read",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_write_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "write",
                             "refId": "B",

--- a/dashboards/MongoDB_Mongos_Instance.json
+++ b/dashboards/MongoDB_Mongos_Instance.json
@@ -1328,7 +1328,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=\"mongos\",alias=~\"$mongos\"}",
+                            "expr": "node_load1{alias=~\"$mongos\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "load1",
@@ -1336,7 +1336,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_load5{cluster=\"$cluster\",nodetype=\"mongos\",alias=~\"$mongos\"}",
+                            "expr": "node_load5{alias=~\"$mongos\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "load5",
@@ -1344,7 +1344,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_load15{cluster=\"$cluster\",nodetype=\"mongos\",alias=~\"$mongos\"}",
+                            "expr": "node_load15{alias=~\"$mongos\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "load15",
@@ -1412,7 +1412,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongos\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongos\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "User",
@@ -1420,7 +1420,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongos\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongos\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "System",
@@ -1428,7 +1428,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongos\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongos\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Idle",
@@ -1436,7 +1436,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongos\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongos\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Iowait",
@@ -1444,7 +1444,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",alias=\"$mongos\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=\"$mongos\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongos\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Other",
@@ -1512,7 +1512,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{cluster=\"$cluster\",nodetype=\"mongos\",alias=~\"$mongos\"}",
+                            "expr": "node_memory_MemAvailable{alias=~\"$mongos\"}",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "Available",
@@ -1520,7 +1520,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=\"mongos\",alias=~\"$mongos\"}",
+                            "expr": "node_memory_MemTotal{alias=~\"$mongos\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Total",
                             "refId": "A",

--- a/dashboards/MongoDB_Standalone_Instance.json
+++ b/dashboards/MongoDB_Standalone_Instance.json
@@ -1766,14 +1766,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_read_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Read",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_write_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Write",
                             "refId": "B",

--- a/dashboards/MongoDB_Standalone_Instance.json
+++ b/dashboards/MongoDB_Standalone_Instance.json
@@ -248,7 +248,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-((node_memory_MemAvailable{nodetype=\"mongod\",alias=\"$mongod\"} or (node_memory_Buffers{nodetype=\"mongod\",alias=\"$mongod\"} + node_memory_Cached{nodetype=\"mongod\",alias=\"$mongod\"}))/node_memory_MemTotal{alias=\"$mongod\"})",
+                            "expr": "1-((node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))/node_memory_MemTotal{alias=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -1602,7 +1602,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{nodetype=\"mongod\",alias=\"$mongod\"} or (node_memory_Buffers{nodetype=\"mongod\",alias=\"$mongod\"} + node_memory_Cached{nodetype=\"mongod\",alias=\"$mongod\"})",
+                            "expr": "node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -1610,7 +1610,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_MemTotal{nodetype=\"mongod\",alias=\"$mongod\"}-(node_memory_MemAvailable{nodetype=\"mongod\",alias=\"$mongod\"} or (node_memory_Buffers{nodetype=\"mongod\",alias=\"$mongod\"} + node_memory_Cached{nodetype=\"mongod\",alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}-(node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "used",
@@ -1618,21 +1618,21 @@
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_MemTotal{nodetype=\"mongod\",alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_Buffers{nodetype=\"mongod\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_Cached{nodetype=\"mongod\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",

--- a/dashboards/MongoDB_WiredTiger.json
+++ b/dashboards/MongoDB_WiredTiger.json
@@ -156,7 +156,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}",
+                            "expr": "node_memory_Cached{alias=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -211,7 +211,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "avg(irate(node_disk_write_time_ms{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
+                            "expr": "avg(irate(node_disk_write_time_ms{alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -266,7 +266,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "avg(irate(node_disk_read_time_ms{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
+                            "expr": "avg(irate(node_disk_read_time_ms{alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -321,7 +321,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "1-(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -1861,21 +1861,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}",
+                            "expr": "node_load1{alias=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "node_load5{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}",
+                            "expr": "node_load5{alias=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 21
                         },
                         {
-                            "expr": "node_load15{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}",
+                            "expr": "node_load15{alias=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -1942,7 +1942,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -1950,7 +1950,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -1958,7 +1958,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -1966,7 +1966,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -1974,7 +1974,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -2044,7 +2044,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"})",
+                            "expr": "node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -2052,7 +2052,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"}-(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}-(node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "used",
@@ -2060,21 +2060,21 @@
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_Buffers{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 21
                         },
                         {
-                            "expr": "node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongod\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{alias=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
@@ -2141,7 +2141,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_read_time_ms{alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "read",
@@ -2149,7 +2149,7 @@
                             "step": 21
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms{cluster=\"$cluster\",nodetype=\"mongod\",alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_write_time_ms{alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "write",
                             "refId": "B",

--- a/template-cleaner.py
+++ b/template-cleaner.py
@@ -55,11 +55,11 @@ if os.path.isfile(fileName):
 	tmpFileName = fileName + ".tmp"
 	tmpFh = open(tmpFileName, "w")
 	jsonOut = json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
-	tmpFh.write(jsonOut)
+	tmpFh.write("%s\n" % jsonOut)
 	tmpFh.close()
 
 	os.rename(tmpFileName, fileName)
-	print "OK"
+	print "Cleaned template: %s" % fileName
 else:
 	print "ERROR: cannot find file!"
 	sys.exit(1)


### PR DESCRIPTION
Removed 'nodetype' and 'cluster' query conditionals from instance-only dashboards who don't need those query filters - only 'alias' is needed on instance-only dashes.

Also mistakenly committed a new Makefile to streamline the template-cleaner.py running, but it is harmless.
