### PR TITLE
Template-based-metrics labels to instance only

### DIFF
--- a/dashboards/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB_Cluster_Summary.json
@@ -4,7 +4,7 @@
     },
     "editable": true,
     "hideControls": false,
-    "id": 2,
+    "id": null,
     "links": [],
     "originalTitle": "MongoDB Cluster Summary",
     "refresh": "10s",
@@ -1933,5 +1933,5 @@
     },
     "timezone": "utc",
     "title": "MongoDB Cluster Summary",
-    "version": 1
+    "version": 0
 }

--- a/dashboards/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB_Cluster_Summary.json
@@ -1592,7 +1592,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "1-(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",mode=\"idle\"}[1m])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\"}[1m])) by (alias))",
+                            "expr": "1-(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",mode=\"idle\"}[1m])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\"}[1m])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "mongos",

--- a/dashboards/MongoDB_Cluster_Summary.json
+++ b/dashboards/MongoDB_Cluster_Summary.json
@@ -1592,7 +1592,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "1-(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\",mode=\"idle\"}[1m])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongos\"}[1m])) by (instance))",
+                            "expr": "avg(1 - sum(delta(node_cpu{mode=\"idle\"}[1m])) by (instance) / sum(delta(node_cpu[1m])) by (instance) * on (instance) group_right up{job=\"mongodb\", cluster=\"$cluster\", nodetype=\"mongos\"}) by (replset)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "mongos",
@@ -1600,7 +1600,7 @@
                             "step": 10
                         },
                         {
-                            "expr": "1-(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\",mode=\"idle\"}[1m])) by (replset)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"mongod\"}[1m])) by (replset))",
+                            "expr": "avg(1 - sum(delta(node_cpu{mode=\"idle\"}[1m])) by (instance) / sum(delta(node_cpu[1m])) by (instance) * on (instance) group_right up{job=\"mongodb\", cluster=\"$cluster\", nodetype=\"mongod\"}) by (replset)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "rs-{{replset}}",
@@ -1608,7 +1608,7 @@
                             "step": 10
                         },
                         {
-                            "expr": "1-(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\",mode=\"idle\"}[1m])) by (replset)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=\"config\"}[1m])) by (replset))",
+                            "expr": "avg(1 - sum(delta(node_cpu{mode=\"idle\"}[1m])) by (instance) / sum(delta(node_cpu[1m])) by (instance) * on (instance) group_right up{job=\"mongodb\", cluster=\"$cluster\", nodetype=\"config\"}) by (replset)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "config",
@@ -1686,7 +1686,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "max(node_load1{cluster=\"$cluster\",nodetype=\"mongos\"}) by (group)",
+                            "expr": "max(node_load1 * on (instance) group_right up{cluster=\"$cluster\", nodetype=\"mongos\"}) by (replset)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "mongos",
@@ -1694,14 +1694,14 @@
                             "step": 10
                         },
                         {
-                            "expr": "max(node_load1{cluster=\"$cluster\",nodetype=\"mongod\"}) by (replset)",
+                            "expr": "max(node_load1 * on (instance) group_right up{cluster=\"$cluster\", nodetype=\"mongod\"}) by (replset)",
                             "intervalFactor": 2,
                             "legendFormat": "rs-{{replset}}",
                             "refId": "D",
                             "step": 10
                         },
                         {
-                            "expr": "max(node_load1{cluster=\"$cluster\",nodetype=\"config\"}) by (replset)",
+                            "expr": "max(node_load1 * on (instance) group_right up{cluster=\"$cluster\", nodetype=\"config\"}) by (replset)",
                             "intervalFactor": 2,
                             "legendFormat": "config",
                             "refId": "B",
@@ -1778,21 +1778,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "1-(avg(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=\"mongos\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=\"mongos\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongos\"})) by (cluster)/avg(node_memory_MemTotal{cluster=\"$cluster\",nodetype=\"mongos\"}) by (cluster))",
+                            "expr": "avg(1 - avg((node_memory_MemAvailable or node_memory_Buffers + node_memory_Cached) / node_memory_MemTotal) by (instance) * on (instance) group_right up{cluster=\"$cluster\", nodetype=\"mongos\"}) by (cluster)",
                             "intervalFactor": 2,
                             "legendFormat": "mongos",
                             "refId": "I",
                             "step": 10
                         },
                         {
-                            "expr": "1-(avg(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=\"mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=\"mongos\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongos\"})) by (replset)/avg(node_memory_MemTotal{cluster=\"$cluster\",nodetype=\"mongod\"}) by (replset))",
+                            "expr": "avg(1 - avg((node_memory_MemAvailable or node_memory_Buffers + node_memory_Cached) / node_memory_MemTotal) by (instance) * on (instance) group_right up{cluster=\"$cluster\", nodetype=\"mongod\"}) by (replset)",
                             "intervalFactor": 2,
                             "legendFormat": "rs-{{replset}}",
                             "refId": "A",
                             "step": 10
                         },
                         {
-                            "expr": "1-(avg(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=\"config\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=\"config\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=\"mongos\"})) by (cluster)/avg(node_memory_MemTotal{cluster=\"$cluster\",nodetype=\"config\"}) by (cluster))",
+                            "expr": "avg(1 - avg((node_memory_MemAvailable or node_memory_Buffers + node_memory_Cached) / node_memory_MemTotal) by (instance) * on (instance) group_right up{cluster=\"$cluster\", nodetype=\"config\"}) by (cluster)",
                             "intervalFactor": 2,
                             "legendFormat": "config",
                             "refId": "B",

--- a/dashboards/MongoDB_Replica_Set.json
+++ b/dashboards/MongoDB_Replica_Set.json
@@ -56,7 +56,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "max(mongodb_mongod_replset_my_state{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"})",
+                            "expr": "max(mongodb_mongod_replset_my_state{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -165,7 +165,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_replset_number_of_members{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_number_of_members{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -223,7 +223,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "time() - mongodb_mongod_replset_member_election_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "time() - mongodb_mongod_replset_member_election_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -281,7 +281,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_load1{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -339,7 +339,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"user\"}[45s]))/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -397,7 +397,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-((node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}))/node_memory_MemTotal{alias=\"$mongod\"})",
+                            "expr": "1-((node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}))/node_memory_MemTotal{instance=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -468,7 +468,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",type!=\"command\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",type!=\"command\"}[45s])",
                             "hide": false,
                             "intervalFactor": 10,
                             "legendFormat": "{{type}}",
@@ -476,7 +476,7 @@
                             "step": 10
                         },
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_repl_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",type!=\"command\",type!=\"query\",type!=\"getmore\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_repl_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",type!=\"command\",type!=\"query\",type!=\"getmore\"}[45s])",
                             "hide": false,
                             "intervalFactor": 10,
                             "legendFormat": "repl_{{type}}",
@@ -573,7 +573,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_connections{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",alias=~\"$mongod\",state=\"current\"}",
+                            "expr": "mongodb_mongod_connections{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\",state=\"current\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Current Connections",
@@ -664,7 +664,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_metrics_cursor_open{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} or mongodb_mongod_cursors{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_metrics_cursor_open{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or mongodb_mongod_cursors{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -761,7 +761,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -850,7 +850,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -947,7 +947,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1037,7 +1037,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_num_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_num_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1046,7 +1046,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtimeouts_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtimeouts_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1144,7 +1144,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_repl_oplog_insert_total_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_repl_oplog_insert_total_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "Oplog Insert Time",
                             "refId": "A",
@@ -1232,7 +1232,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -1331,7 +1331,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "round(increase(mongodb_mongod_asserts_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s]))",
+                            "expr": "round(increase(mongodb_mongod_asserts_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -1428,7 +1428,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "time()-mongodb_mongod_replset_oplog_tail_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "time()-mongodb_mongod_replset_oplog_tail_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Now to End",
@@ -1437,7 +1437,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_replset_oplog_head_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}-mongodb_mongod_replset_oplog_tail_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_oplog_head_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}-mongodb_mongod_replset_oplog_tail_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Oplog Range",
@@ -1527,7 +1527,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "max(mongodb_mongod_replset_member_optime_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",set=\"$replset\",state=\"PRIMARY\"})-min(mongodb_mongod_replset_member_optime_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",set=\"$replset\",state=\"SECONDARY\"})",
+                            "expr": "max(mongodb_mongod_replset_member_optime_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",set=\"$replset\",state=\"PRIMARY\"})-min(mongodb_mongod_replset_member_optime_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",set=\"$replset\",state=\"SECONDARY\"})",
                             "intervalFactor": 2,
                             "legendFormat": "Replication Lag",
                             "refId": "A",
@@ -1625,7 +1625,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_replset_member_uptime{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_member_uptime{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1716,7 +1716,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "max(changes(mongodb_mongod_replset_member_election_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "max(changes(mongodb_mongod_replset_member_election_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Elections",
                             "refId": "A",
@@ -1812,7 +1812,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "time() - max(mongodb_mongod_replset_member_last_heartbeat{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}) by (name)",
+                            "expr": "time() - max(mongodb_mongod_replset_member_last_heartbeat{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}) by (name)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{name}}",
@@ -1902,7 +1902,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_replset_member_ping_ms{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_member_ping_ms{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{name}}",
                             "refId": "A",
@@ -2000,21 +2000,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_load1{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_load5{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_load5{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 2
                         },
                         {
-                            "expr": "node_load15{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_load15{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -2107,7 +2107,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -2115,7 +2115,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -2123,7 +2123,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -2131,7 +2131,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -2139,7 +2139,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -2249,14 +2249,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}-(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}-(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}))",
                             "intervalFactor": 2,
                             "legendFormat": "used",
                             "refId": "E",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "hide": true,
                             "intervalFactor": 2,
                             "legendFormat": "total",
@@ -2264,21 +2264,21 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
                             "step": 2
                         },
                         {
-                            "expr": "(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=\"$mongod\"}))",
+                            "expr": "(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -2374,14 +2374,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_bytes_read{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_disk_bytes_read{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Read",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_bytes_written{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_disk_bytes_written{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Written",
                             "refId": "B",
@@ -2468,7 +2468,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_read_time_ms{instance=\"$mongod\"}[45s]))",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "Read",
@@ -2476,7 +2476,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_write_time_ms{instance=\"$mongod\"}[45s]))",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "Write",
@@ -2572,14 +2572,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_procs_running{alias=\"$mongod\"}",
+                            "expr": "node_procs_running{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Running",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_procs_blocked{alias=\"$mongod\"}",
+                            "expr": "node_procs_blocked{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Blocked",
                             "refId": "B",
@@ -2668,7 +2668,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(node_context_switches{alias=\"$mongod\"}[45s])",
+                            "expr": "irate(node_context_switches{instance=\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "Context Switches",
                             "refId": "B",
@@ -2775,7 +2775,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_network_receive_bytes{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_bytes{instance=\"$mongod\"}[45s])) by (instance)",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "In",
@@ -2784,7 +2784,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_transmit_bytes{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_transmit_bytes{instance=\"$mongod\"}[45s])) by (instance)",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "Out",
@@ -2880,7 +2880,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_netstat_Tcp_CurrEstab{alias=\"$mongod\"}",
+                            "expr": "node_netstat_Tcp_CurrEstab{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Established",
                             "refId": "A",
@@ -2967,21 +2967,21 @@
                     "steppedLine": true,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_network_receive_packets{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_packets{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Packets Total",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_receive_drop{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_drop{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Packets Dropped",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_receive_errs{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_errs{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Packet Errors",
                             "refId": "B",
@@ -3121,7 +3121,7 @@
                 "options": [],
                 "query": "mongodb_mongod_connections{cluster=~\"$cluster\",nodetype=~\"(config|mongod)\",replset=~\"$replset\"}",
                 "refresh": true,
-                "regex": "/alias=\"(.+?)\"/",
+                "regex": "/instance=\"(.+?)\"/",
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false

--- a/dashboards/MongoDB_Replica_Set.json
+++ b/dashboards/MongoDB_Replica_Set.json
@@ -4,7 +4,7 @@
     },
     "editable": true,
     "hideControls": false,
-    "id": 11,
+    "id": null,
     "links": [],
     "originalTitle": "MongoDB Replica Set",
     "refresh": "10s",
@@ -3160,5 +3160,5 @@
     },
     "timezone": "utc",
     "title": "MongoDB Replica Set",
-    "version": 15
+    "version": 0
 }

--- a/dashboards/MongoDB_Replica_Set.json
+++ b/dashboards/MongoDB_Replica_Set.json
@@ -281,7 +281,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_load1{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -339,7 +339,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"user\"}[45s]))/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])))",
+                            "expr": "sum(delta(node_cpu{instance=\"$mongod\", mode=\"user\"}[45s]))/sum(delta(node_cpu{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -397,7 +397,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-((node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}))/node_memory_MemTotal{instance=\"$mongod\"})",
+                            "expr": "1-((node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"}))/node_memory_MemTotal{instance=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -468,7 +468,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",type!=\"command\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_total{instance=\"$mongod\",type!=\"command\"}[45s])",
                             "hide": false,
                             "intervalFactor": 10,
                             "legendFormat": "{{type}}",
@@ -476,7 +476,7 @@
                             "step": 10
                         },
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_repl_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",type!=\"command\",type!=\"query\",type!=\"getmore\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_repl_total{instance=\"$mongod\",type!=\"command\",type!=\"query\",type!=\"getmore\"}[45s])",
                             "hide": false,
                             "intervalFactor": 10,
                             "legendFormat": "repl_{{type}}",
@@ -2000,21 +2000,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_load1{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_load5{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_load5{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 2
                         },
                         {
-                            "expr": "node_load15{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_load15{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -2107,7 +2107,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "sum(delta(node_cpu{instance=\"$mongod\",mode=\"user\"}[45s])) / sum(delta(node_cpu{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -2115,7 +2115,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "sum(delta(node_cpu{instance=\"$mongod\",mode=\"system\"}[45s])) / sum(delta(node_cpu{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -2123,7 +2123,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "sum(delta(node_cpu{instance=\"$mongod\",mode=\"idle\"}[45s])) / sum(delta(node_cpu{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -2131,7 +2131,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "sum(delta(node_cpu{instance=\"$mongod\",mode=\"iowait\"}[45s])) / sum(delta(node_cpu{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -2139,7 +2139,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "sum(delta(node_cpu{instance=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) / sum(delta(node_cpu{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -2249,14 +2249,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}-(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}-(node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"}))",
                             "intervalFactor": 2,
                             "legendFormat": "used",
                             "refId": "E",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}",
                             "hide": true,
                             "intervalFactor": 2,
                             "legendFormat": "total",
@@ -2264,21 +2264,21 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "node_memory_Cached{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
                             "step": 2
                         },
                         {
-                            "expr": "(node_memory_MemAvailable{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or (node_memory_Buffers{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} + node_memory_Cached{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}))",
+                            "expr": "node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -2374,14 +2374,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_bytes_read{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_bytes_read{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Read",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_bytes_written{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_bytes_written{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Written",
                             "refId": "B",
@@ -2775,7 +2775,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_network_receive_bytes{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_network_receive_bytes{instance=\"$mongod\"}[45s]))",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "In",
@@ -2784,7 +2784,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_transmit_bytes{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_network_transmit_bytes{instance=\"$mongod\"}[45s]))",
                             "interval": "",
                             "intervalFactor": 2,
                             "legendFormat": "Out",
@@ -2967,21 +2967,21 @@
                     "steppedLine": true,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_network_receive_packets{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_network_receive_packets{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Packets Total",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_receive_drop{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_network_receive_drop{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Packets Dropped",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_receive_errs{instance=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_network_receive_errs{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Packet Errors",
                             "refId": "B",

--- a/dashboards/MongoDB_Replica_Set.json
+++ b/dashboards/MongoDB_Replica_Set.json
@@ -56,7 +56,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "max(mongodb_mongod_replset_my_state{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"})",
+                            "expr": "max(mongodb_mongod_replset_my_state{instance=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -165,7 +165,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_replset_number_of_members{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_number_of_members{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -223,7 +223,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "time() - mongodb_mongod_replset_member_election_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "time() - mongodb_mongod_replset_member_election_date{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -573,7 +573,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_connections{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\",state=\"current\"}",
+                            "expr": "mongodb_mongod_connections{instance=~\"$mongod\",state=\"current\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Current Connections",
@@ -664,7 +664,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_metrics_cursor_open{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"} or mongodb_mongod_cursors{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "mongodb_mongod_metrics_cursor_open{instance=\"$mongod\"} or mongodb_mongod_cursors{instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -761,7 +761,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{instance=\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -850,7 +850,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -947,7 +947,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1037,7 +1037,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_num_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_num_total{instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1046,7 +1046,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtimeouts_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",replset=\"$replset\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtimeouts_total{instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1144,7 +1144,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_repl_oplog_insert_total_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_repl_oplog_insert_total_milliseconds{instance=\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "Oplog Insert Time",
                             "refId": "A",
@@ -1232,7 +1232,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{instance=\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -1331,7 +1331,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "round(increase(mongodb_mongod_asserts_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s]))",
+                            "expr": "round(increase(mongodb_mongod_asserts_total{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -1428,7 +1428,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "time()-mongodb_mongod_replset_oplog_tail_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "time()-mongodb_mongod_replset_oplog_tail_timestamp{instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Now to End",
@@ -1437,7 +1437,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_replset_oplog_head_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}-mongodb_mongod_replset_oplog_tail_timestamp{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_oplog_head_timestamp{instance=\"$mongod\"}-mongodb_mongod_replset_oplog_tail_timestamp{instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Oplog Range",
@@ -1527,7 +1527,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "max(mongodb_mongod_replset_member_optime_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",set=\"$replset\",state=\"PRIMARY\"})-min(mongodb_mongod_replset_member_optime_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",set=\"$replset\",state=\"SECONDARY\"})",
+                            "expr": "max(mongodb_mongod_replset_member_optime_date{set=\"$replset\",state=\"PRIMARY\"})-min(mongodb_mongod_replset_member_optime_date{instance=\"$mongod\",set=\"$replset\",state=\"SECONDARY\"})",
                             "intervalFactor": 2,
                             "legendFormat": "Replication Lag",
                             "refId": "A",
@@ -1625,7 +1625,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_replset_member_uptime{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_member_uptime{instance=\"$mongod\"}",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -1716,7 +1716,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "max(changes(mongodb_mongod_replset_member_election_date{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}[45s]))",
+                            "expr": "max(changes(mongodb_mongod_replset_member_election_date{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Elections",
                             "refId": "A",
@@ -1812,7 +1812,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "time() - max(mongodb_mongod_replset_member_last_heartbeat{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}) by (name)",
+                            "expr": "time() - max(mongodb_mongod_replset_member_last_heartbeat{instance=\"$mongod\"}) by (name)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{name}}",
@@ -1902,7 +1902,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_replset_member_ping_ms{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\"}",
+                            "expr": "mongodb_mongod_replset_member_ping_ms{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{name}}",
                             "refId": "A",

--- a/dashboards/MongoDB_RocksDB.json
+++ b/dashboards/MongoDB_RocksDB.json
@@ -49,7 +49,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",type=\"total\"}",
+                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"total\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -105,7 +105,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "refId": "A",
                             "step": 11
@@ -160,7 +160,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_memory_Cached{alias=~\"$mongod\"}",
+                            "expr": "node_memory_Cached{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -216,7 +216,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "avg(irate(node_disk_write_time_ms{alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
+                            "expr": "avg(irate(node_disk_write_time_ms{instance=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m]))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -272,7 +272,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "avg(irate(node_disk_read_time_ms{alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
+                            "expr": "avg(irate(node_disk_read_time_ms{instance=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m]))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -328,7 +328,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "1-(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -411,14 +411,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_writes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_writes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_write_batches_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_write_batches_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "batched",
                             "refId": "C",
@@ -488,7 +488,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_operations_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_operations_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -567,14 +567,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "memtable_{{type}}",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "block_cache_total",
                             "refId": "B",
@@ -644,14 +644,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_memtable_active_entries{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_memtable_active_entries{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "active",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_rocksdb_immutable_memtable_entries{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_immutable_memtable_entries{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "immutable",
                             "refId": "B",
@@ -735,7 +735,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_rocksdb_compaction_seconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
+                            "expr": "increase(mongodb_mongod_rocksdb_compaction_seconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
                             "refId": "B",
@@ -811,7 +811,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_compaction_write_amplification{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_compaction_write_amplification{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
                             "refId": "A",
@@ -895,7 +895,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_size_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level!=\"Sum\"}",
+                            "expr": "mongodb_mongod_rocksdb_size_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
                             "refId": "A",
@@ -971,7 +971,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_rocksdb_compaction_keys_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
+                            "expr": "increase(mongodb_mongod_rocksdb_compaction_keys_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}_{{type}}",
                             "refId": "A",
@@ -1054,7 +1054,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level!=\"Sum\",type=~\"read.*\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\",type=~\"read.*\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}-{{type}}",
@@ -1133,7 +1133,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level!=\"Sum\",type=~\"write.*\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\",type=~\"write.*\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}-{{type}}",
@@ -1213,7 +1213,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_compaction_file_threads{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level!=\"Sum\"}",
+                            "expr": "mongodb_mongod_rocksdb_compaction_file_threads{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
@@ -1285,7 +1285,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_num_files{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",level!=\"Sum\"}",
+                            "expr": "mongodb_mongod_rocksdb_num_files{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
@@ -1370,7 +1370,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "Write Rate",
                             "refId": "A",
@@ -1446,7 +1446,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_write_ahead_log_writes_per_sync{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_write_ahead_log_writes_per_sync{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Writes per Sync",
                             "refId": "A",
@@ -1528,7 +1528,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_flushed_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_rocksdb_flushed_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "flush",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1603,7 +1603,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_pending_compactions{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_pending_compactions{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "compactions",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1611,7 +1611,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_rocksdb_pending_memtable_flushes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_pending_memtable_flushes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "memtable_flushes",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1693,7 +1693,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_stalled_seconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_stalled_seconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Time Stalled",
@@ -1764,7 +1764,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_rocksdb_stalls_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_rocksdb_stalls_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1842,7 +1842,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -1913,7 +1913,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
                             "metric": "",
@@ -1921,7 +1921,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "moved",
                             "refId": "B",
@@ -1997,7 +1997,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -2066,7 +2066,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -2145,21 +2145,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{alias=~\"$mongod\"}",
+                            "expr": "node_load1{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_load5{alias=~\"$mongod\"}",
+                            "expr": "node_load5{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 2
                         },
                         {
-                            "expr": "node_load15{alias=~\"$mongod\"}",
+                            "expr": "node_load15{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -2229,7 +2229,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -2237,7 +2237,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -2245,7 +2245,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -2253,7 +2253,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -2261,7 +2261,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -2333,7 +2333,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"})",
+                            "expr": "node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -2341,7 +2341,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}-(node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}-(node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "used",
@@ -2349,21 +2349,21 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Buffers{alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Cached{alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
@@ -2446,7 +2446,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms{alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance,device)",
+                            "expr": "sum(irate(node_disk_read_time_ms{instance=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (device)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{device}}_r",
@@ -2454,7 +2454,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms{alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance,device)",
+                            "expr": "sum(irate(node_disk_write_time_ms{instance=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (device)",
                             "intervalFactor": 2,
                             "legendFormat": "{{device}}_w",
                             "refId": "B",
@@ -2559,7 +2559,7 @@
                 "options": [],
                 "query": "mongodb_mongod_rocksdb_background_errors{cluster=~\"$cluster\",nodetype=~\"(config|mongod)\"}",
                 "refresh": true,
-                "regex": "/alias=\"(.+?)\"/",
+                "regex": "/instance=\"(.+?)\"/",
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false

--- a/dashboards/MongoDB_RocksDB.json
+++ b/dashboards/MongoDB_RocksDB.json
@@ -49,7 +49,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"total\"}",
+                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{instance=~\"$mongod\",type=\"total\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -105,7 +105,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "refId": "A",
                             "step": 11
@@ -405,7 +405,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -482,21 +482,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_writes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_writes_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_write_batches_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_write_batches_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "batched",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_operations_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_operations_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "WAL-{{type}}",
                             "refId": "B",
@@ -574,14 +574,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_memtable_bytes{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "memtable_{{type}}",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_block_cache_bytes{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "block_cache_total",
                             "refId": "B",
@@ -651,14 +651,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_memtable_active_entries{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_memtable_active_entries{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "active",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_rocksdb_immutable_memtable_entries{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_immutable_memtable_entries{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "immutable",
                             "refId": "B",
@@ -742,7 +742,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_rocksdb_compaction_seconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
+                            "expr": "increase(mongodb_mongod_rocksdb_compaction_seconds_total{instance=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
                             "refId": "B",
@@ -818,7 +818,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_compaction_write_amplification{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_compaction_write_amplification{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
                             "refId": "A",
@@ -902,7 +902,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_size_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\"}",
+                            "expr": "mongodb_mongod_rocksdb_size_bytes{instance=~\"$mongod\",level!=\"Sum\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
                             "refId": "A",
@@ -978,7 +978,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_compaction_keys_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_compaction_keys_total{instance=~\"$mongod\",level=~\"L[0-9]\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}_{{type}}",
                             "refId": "A",
@@ -1061,7 +1061,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\",type=~\"read.*\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{instance=~\"$mongod\",level!=\"Sum\",type=~\"read.*\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}-{{type}}",
@@ -1140,7 +1140,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\",type=~\"write.*\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_compaction_bytes_total{instance=~\"$mongod\",level!=\"Sum\",type=~\"write.*\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}-{{type}}",
@@ -1220,7 +1220,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_compaction_file_threads{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\"}",
+                            "expr": "mongodb_mongod_rocksdb_compaction_file_threads{instance=~\"$mongod\",level!=\"Sum\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
@@ -1292,7 +1292,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_num_files{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",level!=\"Sum\"}",
+                            "expr": "mongodb_mongod_rocksdb_num_files{instance=~\"$mongod\",level!=\"Sum\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{level}}",
@@ -1377,7 +1377,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_rocksdb_write_ahead_log_bytes_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "Write Rate",
                             "refId": "A",
@@ -1453,7 +1453,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_write_ahead_log_writes_per_sync{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_write_ahead_log_writes_per_sync{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Writes per Sync",
                             "refId": "A",
@@ -1535,7 +1535,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_rocksdb_flushed_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_rocksdb_flushed_bytes_total{instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "Flush Rate",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1610,7 +1610,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_rocksdb_pending_compactions{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_pending_compactions{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "compactions",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1618,7 +1618,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_rocksdb_pending_memtable_flushes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_rocksdb_pending_memtable_flushes{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "memtable_flushes",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1700,7 +1700,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_rocksdb_stalled_seconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_rocksdb_stalled_seconds_total{instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Time Stalled",
@@ -1771,7 +1771,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_rocksdb_stalls_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_rocksdb_stalls_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1849,7 +1849,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",type!=\"command\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_total{instance=\"$mongod\",type!=\"command\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1857,7 +1857,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_repl_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=\"$mongod\",type!=\"command\",type!=\"query\",type!=\"getmore\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_repl_total{instance=\"$mongod\",type!=\"command\",type!=\"query\",type!=\"getmore\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "repl_{{type}}",
                             "metric": "mongodb_mongod_rocksdb_concurrent_transactions_tickets_total",
@@ -1928,7 +1928,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
                             "metric": "",
@@ -1936,7 +1936,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "moved",
                             "refId": "B",
@@ -2012,7 +2012,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -2081,7 +2081,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",

--- a/dashboards/MongoDB_RocksDB.json
+++ b/dashboards/MongoDB_RocksDB.json
@@ -4,7 +4,7 @@
     },
     "editable": true,
     "hideControls": false,
-    "id": 2,
+    "id": null,
     "links": [],
     "originalTitle": "MongoDB RocksDB",
     "refresh": "10s",
@@ -2613,5 +2613,5 @@
     },
     "timezone": "utc",
     "title": "MongoDB RocksDB",
-    "version": 3
+    "version": 0
 }

--- a/dashboards/MongoDB_Standalone_Instance.json
+++ b/dashboards/MongoDB_Standalone_Instance.json
@@ -4,7 +4,7 @@
     },
     "editable": true,
     "hideControls": false,
-    "id": 5,
+    "id": null,
     "links": [],
     "originalTitle": "MongoDB Standalone Instance",
     "refresh": "10s",
@@ -2137,5 +2137,5 @@
     },
     "timezone": "utc",
     "title": "MongoDB Standalone Instance",
-    "version": 1
+    "version": 0
 }

--- a/dashboards/MongoDB_Standalone_Instance.json
+++ b/dashboards/MongoDB_Standalone_Instance.json
@@ -56,7 +56,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_load1{alias=\"$mongod\"}",
+                            "expr": "node_load1{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -114,7 +114,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"user\"}[45s]))/sum(delta(node_cpu{instance=\"$mongod\"}[45s])))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -172,7 +172,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"system\"}[45s]))/sum(delta(node_cpu{instance=\"$mongod\"}[45s])))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -230,7 +230,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (instance))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"iowait\"}[45s]))/sum(delta(node_cpu{instance=\"$mongod\"}[45s])))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -288,7 +288,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-((node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))/node_memory_MemTotal{alias=\"$mongod\"})",
+                            "expr": "1-((node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"}))/node_memory_MemTotal{instance=\"$mongod\"})",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -345,7 +345,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "sum(irate(mongodb_mongod_op_counters_total{alias=\"$mongod\",type!=\"command\"}[45s]))",
+                            "expr": "sum(irate(mongodb_mongod_op_counters_total{instance=\"$mongod\",type!=\"command\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "metric": "",
@@ -409,7 +409,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_op_counters_total{alias=\"$mongod\",type!=\"command\"}[45s])",
+                            "expr": "irate(mongodb_mongod_op_counters_total{instance=\"$mongod\",type!=\"command\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -493,7 +493,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_connections{alias=~\"$mongod\",state=\"current\"}",
+                            "expr": "mongodb_mongod_connections{instance=~\"$mongod\",state=\"current\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Current Connections",
@@ -569,7 +569,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_metrics_cursor_open{alias=\"$mongod\"} or mongodb_mongod_cursors{alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_metrics_cursor_open{instance=\"$mongod\"} or mongodb_mongod_cursors{instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -653,7 +653,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{alias=\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{instance=\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -729,7 +729,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{alias=\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{instance=\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -814,7 +814,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_total_milliseconds{instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -892,7 +892,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_num_total{alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtime_num_total{instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -901,7 +901,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtimeouts_total{alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_metrics_get_last_error_wtimeouts_total{instance=~\"$mongod\"}[1m])",
                             "hide": false,
                             "interval": "",
                             "intervalFactor": 2,
@@ -986,7 +986,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{alias=\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{instance=\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -1064,7 +1064,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "round(increase(mongodb_mongod_asserts_total{alias=\"$mongod\"}[45s]))",
+                            "expr": "round(increase(mongodb_mongod_asserts_total{instance=\"$mongod\"}[45s]))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -1148,21 +1148,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{alias=\"$mongod\"}",
+                            "expr": "node_load1{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_load5{alias=\"$mongod\"}",
+                            "expr": "node_load5{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 2
                         },
                         {
-                            "expr": "node_load15{alias=\"$mongod\"}",
+                            "expr": "node_load15{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -1237,7 +1237,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -1245,7 +1245,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -1253,7 +1253,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -1261,7 +1261,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -1269,7 +1269,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{instance=\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -1355,7 +1355,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"})",
+                            "expr": "node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -1363,7 +1363,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}-(node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}-(node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "used",
@@ -1371,21 +1371,21 @@
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Buffers{alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "node_memory_Cached{alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
@@ -1468,14 +1468,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_bytes_read{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_disk_bytes_read{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Read",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_bytes_written{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_disk_bytes_written{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Written",
                             "refId": "B",
@@ -1550,14 +1550,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_read_time_ms{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Read",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms{alias=\"$mongod\"}[45s])) by (instance)",
+                            "expr": "sum(irate(node_disk_write_time_ms{instance=\"$mongod\"}[45s]))",
                             "intervalFactor": 2,
                             "legendFormat": "Write",
                             "refId": "B",
@@ -1640,14 +1640,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_procs_running{alias=\"$mongod\"}",
+                            "expr": "node_procs_running{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Running",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "node_procs_blocked{alias=\"$mongod\"}",
+                            "expr": "node_procs_blocked{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Blocked",
                             "refId": "B",
@@ -1724,7 +1724,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(node_context_switches{alias=\"$mongod\"}[45s])",
+                            "expr": "irate(node_context_switches{instance=\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "Context Switches",
                             "refId": "B",
@@ -1815,14 +1815,14 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_network_receive_bytes{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_bytes{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "In",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_transmit_bytes{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_transmit_bytes{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Out",
                             "refId": "B",
@@ -1905,7 +1905,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_netstat_Tcp_CurrEstab{alias=\"$mongod\"}",
+                            "expr": "node_netstat_Tcp_CurrEstab{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Established",
                             "refId": "A",
@@ -1980,21 +1980,21 @@
                     "steppedLine": true,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_network_receive_packets{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_packets{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Packets Total",
                             "refId": "C",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_receive_drop{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_drop{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Packets Dropped",
                             "refId": "A",
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_network_receive_errs{alias=\"$mongod\"}[45s])) by (alias)",
+                            "expr": "sum(irate(node_network_receive_errs{instance=\"$mongod\"}[45s])) by (instance)",
                             "intervalFactor": 2,
                             "legendFormat": "Packet Errors",
                             "refId": "B",
@@ -2098,7 +2098,7 @@
                 "options": [],
                 "query": "mongodb_mongod_connections{}",
                 "refresh": true,
-                "regex": "/alias=\"(.+?)\"/",
+                "regex": "/instance=\"(.+?)\"/",
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false

--- a/dashboards/MongoDB_WiredTiger.json
+++ b/dashboards/MongoDB_WiredTiger.json
@@ -4,7 +4,7 @@
     },
     "editable": true,
     "hideControls": false,
-    "id": 10,
+    "id": null,
     "links": [],
     "originalTitle": "MongoDB WiredTiger",
     "refresh": "10s",
@@ -2180,5 +2180,5 @@
     },
     "timezone": "utc",
     "title": "MongoDB WiredTiger",
-    "version": 9
+    "version": 0
 }

--- a/dashboards/MongoDB_WiredTiger.json
+++ b/dashboards/MongoDB_WiredTiger.json
@@ -49,7 +49,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",type=\"total\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"total\"}",
                             "intervalFactor": 2,
                             "refId": "A",
                             "step": 2
@@ -104,7 +104,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "refId": "A",
                             "step": 2
@@ -159,7 +159,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "node_memory_Cached{alias=~\"$mongod\"}",
+                            "expr": "node_memory_Cached{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -215,7 +215,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "avg(irate(node_disk_write_time_ms{alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
+                            "expr": "avg(irate(node_disk_write_time_ms{instance=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m]))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -271,7 +271,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "avg(irate(node_disk_read_time_ms{alias=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m])) by (instance)",
+                            "expr": "avg(irate(node_disk_read_time_ms{instance=~\"$mongod\",device=~\"(sd|xvd|hd)[a-z]\"}[5m]))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -327,7 +327,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "1-(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "1-(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "intervalFactor": 2,
                             "legendFormat": "",
                             "refId": "A",
@@ -404,7 +404,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -474,7 +474,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",type=\"read\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"read\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "read",
@@ -482,7 +482,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",type=\"written\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"written\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "written",
@@ -561,7 +561,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_blockmanager_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_blockmanager_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -631,7 +631,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_session_open_cursors_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_session_open_cursors_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Cursors",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -639,7 +639,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_session_open_sessions_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_session_open_sessions_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Sessions",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -721,7 +721,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}_total",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -729,7 +729,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}_active",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -812,7 +812,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "current",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -820,7 +820,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -891,7 +891,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_cache_evicted_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_cache_evicted_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -972,7 +972,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Maximum",
@@ -980,7 +980,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\",type=\"total\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"total\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Used",
@@ -1049,7 +1049,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_overhead_percent{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_overhead_percent{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Cache Overhead",
                             "refId": "A",
@@ -1127,7 +1127,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_pages{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_pages{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1197,7 +1197,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_log_operations_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_log_operations_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1275,7 +1275,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_log_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_log_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1346,7 +1346,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_log_records_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_log_records_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -1425,7 +1425,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -1496,7 +1496,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
                             "metric": "",
@@ -1504,7 +1504,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "moved",
                             "refId": "B",
@@ -1580,7 +1580,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -1649,7 +1649,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",alias=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
@@ -1728,21 +1728,21 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_load1{alias=~\"$mongod\"}",
+                            "expr": "node_load1{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load1",
                             "refId": "A",
                             "step": 11
                         },
                         {
-                            "expr": "node_load5{alias=~\"$mongod\"}",
+                            "expr": "node_load5{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load5",
                             "refId": "B",
                             "step": 11
                         },
                         {
-                            "expr": "node_load15{alias=~\"$mongod\"}",
+                            "expr": "node_load15{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "load15",
                             "refId": "C",
@@ -1812,7 +1812,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "user",
@@ -1820,7 +1820,7 @@
                             "step": 11
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"system\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"system\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "system",
@@ -1828,7 +1828,7 @@
                             "step": 11
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"idle\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"idle\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "idle",
@@ -1836,7 +1836,7 @@
                             "step": 11
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode=\"iowait\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode=\"iowait\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "iowait",
@@ -1844,7 +1844,7 @@
                             "step": 11
                         },
                         {
-                            "expr": "(sum(delta(node_cpu{alias=~\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (alias)/sum(delta(node_cpu{alias=~\"$mongod\"}[45s])) by (alias))",
+                            "expr": "(sum(delta(node_cpu{instance=~\"$mongod\",mode!=\"iowait\",mode!=\"idle\",mode!=\"system\",mode!=\"user\"}[45s])) by (instance)/sum(delta(node_cpu{instance=~\"$mongod\"}[45s])) by (instance))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "other",
@@ -1916,7 +1916,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"})",
+                            "expr": "node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"})",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "available",
@@ -1924,7 +1924,7 @@
                             "step": 11
                         },
                         {
-                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}-(node_memory_MemAvailable{alias=\"$mongod\"} or (node_memory_Buffers{alias=\"$mongod\"} + node_memory_Cached{alias=\"$mongod\"}))",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}-(node_memory_MemAvailable{instance=\"$mongod\"} or (node_memory_Buffers{instance=\"$mongod\"} + node_memory_Cached{instance=\"$mongod\"}))",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "used",
@@ -1932,21 +1932,21 @@
                             "step": 11
                         },
                         {
-                            "expr": "node_memory_MemTotal{alias=\"$mongod\"}",
+                            "expr": "node_memory_MemTotal{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "total",
                             "refId": "A",
                             "step": 11
                         },
                         {
-                            "expr": "node_memory_Buffers{alias=\"$mongod\"}",
+                            "expr": "node_memory_Buffers{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "buffers",
                             "refId": "C",
                             "step": 11
                         },
                         {
-                            "expr": "node_memory_Cached{alias=\"$mongod\"}",
+                            "expr": "node_memory_Cached{instance=\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "cached",
                             "refId": "D",
@@ -2029,7 +2029,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "sum(irate(node_disk_read_time_ms{alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance,device)",
+                            "expr": "sum(irate(node_disk_read_time_ms{instance=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (device)",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{device}}_r",
@@ -2037,7 +2037,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "sum(irate(node_disk_write_time_ms{alias=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (instance,device)",
+                            "expr": "sum(irate(node_disk_write_time_ms{instance=~\"$mongod\",device=~\"(sd[a-z]|xvd[a-z]|hd[a-z]|cciss|md)\"}[45s])) by (device)",
                             "intervalFactor": 2,
                             "legendFormat": "{{device}}_w",
                             "refId": "B",
@@ -2141,7 +2141,7 @@
                 "options": [],
                 "query": "mongodb_mongod_wiredtiger_transactions_total{cluster=~\"$cluster\",nodetype=~\"(config|mongod)\"}",
                 "refresh": true,
-                "regex": "/alias=\"(.+?)\"/",
+                "regex": "/instance=\"(.+?)\"/",
                 "tagsQuery": "",
                 "type": "query",
                 "useTags": false

--- a/dashboards/MongoDB_WiredTiger.json
+++ b/dashboards/MongoDB_WiredTiger.json
@@ -49,7 +49,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"total\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{instance=~\"$mongod\",type=\"total\"}",
                             "intervalFactor": 2,
                             "refId": "A",
                             "step": 2
@@ -104,7 +104,7 @@
                     },
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "refId": "A",
                             "step": 2
@@ -404,7 +404,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -474,7 +474,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"read\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{instance=~\"$mongod\",type=\"read\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "read",
@@ -482,7 +482,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"written\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_cache_bytes_total{instance=~\"$mongod\",type=\"written\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "written",
@@ -561,7 +561,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_blockmanager_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_blockmanager_bytes_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -631,7 +631,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_session_open_cursors_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_session_open_cursors_total{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Cursors",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -639,7 +639,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_session_open_sessions_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_session_open_sessions_total{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Sessions",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -721,7 +721,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_total_tickets{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}_total",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -729,7 +729,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_concurrent_transactions_out_tickets{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}_active",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -812,7 +812,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds_total{instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "current",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -820,7 +820,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_transactions_checkpoint_milliseconds{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -891,7 +891,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_cache_evicted_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_cache_evicted_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -972,7 +972,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_max_bytes{instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Maximum",
@@ -980,7 +980,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\",type=\"total\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_bytes{instance=~\"$mongod\",type=\"total\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "Used",
@@ -1049,7 +1049,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_overhead_percent{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_overhead_percent{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "Cache Overhead",
                             "refId": "A",
@@ -1127,7 +1127,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_wiredtiger_cache_pages{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_wiredtiger_cache_pages{instance=~\"$mongod\"}",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1197,7 +1197,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_log_operations_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_log_operations_total{instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1275,7 +1275,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_log_bytes_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_log_bytes_total{instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "refId": "A",
@@ -1346,7 +1346,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_wiredtiger_log_records_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[1m])",
+                            "expr": "irate(mongodb_mongod_wiredtiger_log_records_total{instance=~\"$mongod\"}[1m])",
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",
                             "metric": "mongodb_mongod_wiredtiger_concurrent_transactions_tickets_total",
@@ -1425,7 +1425,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "irate(mongodb_mongod_metrics_document_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "irate(mongodb_mongod_metrics_document_total{instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
@@ -1496,7 +1496,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_query_executor_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "{{state}}",
                             "metric": "",
@@ -1504,7 +1504,7 @@
                             "step": 2
                         },
                         {
-                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "increase(mongodb_mongod_metrics_record_moves_total{instance=~\"$mongod\"}[45s])",
                             "intervalFactor": 2,
                             "legendFormat": "moved",
                             "refId": "B",
@@ -1580,7 +1580,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}[45s])",
+                            "expr": "delta(mongodb_mongod_extra_info_page_faults_total{instance=~\"$mongod\"}[45s])",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "faults",
@@ -1649,7 +1649,7 @@
                     "steppedLine": false,
                     "targets": [
                         {
-                            "expr": "mongodb_mongod_global_lock_current_queue{cluster=\"$cluster\",nodetype=~\"(config|mongod)\",instance=~\"$mongod\"}",
+                            "expr": "mongodb_mongod_global_lock_current_queue{instance=~\"$mongod\"}",
                             "hide": false,
                             "intervalFactor": 2,
                             "legendFormat": "{{type}}",


### PR DESCRIPTION
To resolve #61 (needless use of nodetype + cluster labels on templated dashboards), this removes them because they're already known via the $mongod variable.

Depends on #59, or that PR would break this one.
